### PR TITLE
fix json escape quotes

### DIFF
--- a/src/lib/Libcmds/pbs_json.c
+++ b/src/lib/Libcmds/pbs_json.c
@@ -146,6 +146,11 @@ strdup_escape(const char *str)
 				buf[i++] = 't';
 				str++;
 				break;
+			case '"':
+				buf[i++] = '\\';
+				buf[i++] = '"';
+				str++;
+				break;
 			default:
 				buf[i++] = *str++;
 			}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Bug/feature Description
* json strings containing quotes are not properly escaped
* faulty situation in the output `pbsnodes -a -F json`
```
                "scratch_local":"2097152kb"
            },
            "comment":"HEALTH-CHECK: /var/spool/pbs/mom_scripts/torpedo.d/reboot "zaskly sdileny scratch" (Sep 04 14:13 SCHEDULED)",
            "resv_enable":"True",
```
* steps to reproduce: add user comment containing double-quotes

#### Affected Platform(s)
* debian 9

#### Cause / Analysis / Design
* missing escaping in `src/lib/Libcmds/pbs_json.c::strdup_escape(const char *str)`

#### Solution Description
* escape double-quotes

#### Testing logs/output
* none test provided in PR